### PR TITLE
feat: make notifications as context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,130 +1,14 @@
 import 'react-native-gesture-handler'
 import AuthProvider from './src/context/Auth'
+import NotificationsProvider from './src/context/Notifications'
 import Routes from './src/routes'
-import { useState, useEffect, useRef } from 'react';
-import { Text, View, Button, Platform, Alert } from 'react-native';
-import * as Device from 'expo-device';
-import * as Notifications from 'expo-notifications';
-import Constants from 'expo-constants';
-
-Notifications.setNotificationHandler({
-	handleNotification: async () => ({
-		shouldShowAlert: true,
-		shouldPlaySound: false,
-		shouldSetBadge: false,
-	}),
-});
-
-// Can use this function below or use Expo's Push Notification Tool from: https://expo.dev/notifications
-async function sendPushNotification(expoPushToken: string) {
-	const message = {
-		to: expoPushToken,
-		sound: 'default',
-		title: 'Original Title',
-		body: 'And here is the body!',
-		data: { someData: 'goes here' },
-	};
-  
-	await fetch('https://exp.host/--/api/v2/push/send', {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Accept-encoding': 'gzip, deflate',
-			'Content-Type': 'application/json',
-	  	},
-	  	body: JSON.stringify(message),
-	});
-}
-
-async function registerForPushNotificationsAsync() {
-	let token = {} as Notifications.ExpoPushToken;
-  
-	if (Platform.OS === 'android') {
-		await Notifications.setNotificationChannelAsync('default', {
-			name: 'default',
-			importance: Notifications.AndroidImportance.MAX,
-			vibrationPattern: [0, 250, 250, 250],
-			lightColor: '#FF231F7C',
-	  	});
-	}
-  
-	if (Device.isDevice) {
-	  	const { status: existingStatus } = await Notifications.getPermissionsAsync();
-	  	let finalStatus = existingStatus;
-	  	if (existingStatus !== 'granted') {
-			const { status } = await Notifications.requestPermissionsAsync();
-			finalStatus = status;
-	  	}
-	  	if (finalStatus !== 'granted') {
-			Alert.alert('Notifications', 'Failed to get push token for push notification!', [
-				{text: 'OK', onPress: () => console.log('OK Pressed')},
-			]);
-			return;
-	  	}
-
-		// Gambiarra
-		if (Constants.expoConfig?.extra){
-			token = await Notifications.getExpoPushTokenAsync({
-				projectId: Constants.expoConfig.extra.eas.projectId,
-			});
-		} else {
-			Alert.alert('Notifications', 'Error on ExpoConfig', [
-				{text: 'OK', onPress: () => console.log('OK Pressed')},
-			]);
-		}
-	  	console.log(token);
-	} else {
-		Alert.alert('Notifications', 'Must use physical device for Push Notifications', [
-			{text: 'OK', onPress: () => console.log('OK Pressed')},
-		]);
-	}
-  
-	return token.data;
-}
 
 export default function App() {
-
-	const [expoPushToken, setExpoPushToken] = useState('');
-	const [notification, setNotification] = useState(null as Notifications.Notification | null);
-	const notificationListener = useRef({} as Notifications.Subscription);
-	const responseListener = useRef({} as Notifications.Subscription);
-
-	useEffect(() => {
-
-		registerForPushNotificationsAsync().then(token => setExpoPushToken(token || ''));
-
-		notificationListener.current = Notifications.addNotificationReceivedListener(notification => {
-			setNotification(notification);
-		});
-
-		responseListener.current = Notifications.addNotificationResponseReceivedListener(response => {
-			console.log(response);
-		});
-
-		return () => {
-			Notifications.removeNotificationSubscription(notificationListener.current);
-			Notifications.removeNotificationSubscription(responseListener.current);
-		};
-	}, []);
-
-
 	return (
 		<AuthProvider>
-			<View style={{ flex: 1, alignItems: 'center', justifyContent: 'space-around' }}>
-				<Text>Your expo push token: {expoPushToken}</Text>
-				<View style={{ alignItems: 'center', justifyContent: 'center' }}>
-					<Text>Title: {notification && notification.request.content.title} </Text>
-					<Text>Body: {notification && notification.request.content.body}</Text>
-					<Text>Data: {notification && JSON.stringify(notification.request.content.data)}</Text>
-				</View>
-				<Button
-					title="Press to Send Notification"
-					onPress={async () => {
-						await sendPushNotification(expoPushToken);
-					}}
-				/>
-    		</View>
-			<Routes />
+			<NotificationsProvider>
+				<Routes />
+			</NotificationsProvider>
 		</AuthProvider>
 	)
 }

--- a/src/components/CustomDrawer/index.tsx
+++ b/src/components/CustomDrawer/index.tsx
@@ -74,6 +74,11 @@ const CustomDrawerContent = (props: DrawerContentComponentProps) => {
 									label='Informações'
 									style={{ backgroundColor: '#cfe9e5' }}
 								>
+									<SubItem
+										label='Notificações'
+										onPress={() => props.navigation.navigate('Notifications')}
+										underline={true}
+									/>
 									<SubItem label='Dicas' onPress={() => console.log('Dicas')} underline={false} />
 								</Item>
 								<Item

--- a/src/context/Notifications.tsx
+++ b/src/context/Notifications.tsx
@@ -1,0 +1,131 @@
+import Constants from 'expo-constants'
+import * as Device from 'expo-device'
+import * as Notifications from 'expo-notifications'
+import { createContext, useEffect, useRef, useState } from 'react'
+import { Alert, Platform } from 'react-native'
+import 'react-native-gesture-handler'
+
+type NotificationsContextType = {
+	expoPushToken: string
+	notification: Notifications.Notification | null
+	sendPushNotification: (expoPushToken: string) => void
+}
+
+export const NotificationsContext = createContext<NotificationsContextType>({
+	expoPushToken: '',
+	notification: null,
+	sendPushNotification: () => {},
+})
+
+Notifications.setNotificationHandler({
+	handleNotification: async () => ({
+		shouldShowAlert: true,
+		shouldPlaySound: false,
+		shouldSetBadge: false,
+	}),
+})
+
+// Can use this function below or use Expo's Push Notification Tool from: https://expo.dev/notifications
+async function sendPushNotification(expoPushToken: string) {
+	const message = {
+		to: expoPushToken,
+		sound: 'default',
+		title: 'Original Title',
+		body: 'And here is the body!',
+		data: { someData: 'goes here' },
+	}
+
+	await fetch('https://exp.host/--/api/v2/push/send', {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Accept-encoding': 'gzip, deflate',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(message),
+	})
+}
+
+async function registerForPushNotificationsAsync() {
+	let token = {} as Notifications.ExpoPushToken
+
+	if (Platform.OS === 'android') {
+		await Notifications.setNotificationChannelAsync('default', {
+			name: 'default',
+			importance: Notifications.AndroidImportance.MAX,
+			vibrationPattern: [0, 250, 250, 250],
+			lightColor: '#FF231F7C',
+		})
+	}
+
+	if (Device.isDevice) {
+		const { status: existingStatus } = await Notifications.getPermissionsAsync()
+		let finalStatus = existingStatus
+		if (existingStatus !== 'granted') {
+			const { status } = await Notifications.requestPermissionsAsync()
+			finalStatus = status
+		}
+		if (finalStatus !== 'granted') {
+			Alert.alert('Notifications', 'Failed to get push token for push notification!', [
+				{ text: 'OK', onPress: () => console.log('OK Pressed') },
+			])
+			return
+		}
+
+		// Gambiarra
+		if (Constants.expoConfig?.extra) {
+			token = await Notifications.getExpoPushTokenAsync({
+				projectId: Constants.expoConfig.extra.eas.projectId,
+			})
+		} else {
+			Alert.alert('Notifications', 'Error on ExpoConfig', [
+				{ text: 'OK', onPress: () => console.log('OK Pressed') },
+			])
+		}
+		console.log(token)
+	} else {
+		Alert.alert('Notifications', 'Must use physical device for Push Notifications', [
+			{ text: 'OK', onPress: () => console.log('OK Pressed') },
+		])
+	}
+
+	return token.data
+}
+
+const NotificationsProvider = ({ children }: any) => {
+	const [expoPushToken, setExpoPushToken] = useState('')
+	const [notification, setNotification] = useState(null as Notifications.Notification | null)
+	const notificationListener = useRef({} as Notifications.Subscription)
+	const responseListener = useRef({} as Notifications.Subscription)
+
+	useEffect(() => {
+		registerForPushNotificationsAsync().then((token) => setExpoPushToken(token || ''))
+
+		notificationListener.current = Notifications.addNotificationReceivedListener((notification) => {
+			setNotification(notification)
+		})
+
+		responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
+			console.log(response)
+		})
+
+		return () => {
+			Notifications.removeNotificationSubscription(notificationListener.current)
+			Notifications.removeNotificationSubscription(responseListener.current)
+		}
+	}, [])
+
+	return (
+		<NotificationsContext.Provider
+			value={{
+				expoPushToken,
+				notification,
+				sendPushNotification,
+			}}
+		>
+			{children}
+		</NotificationsContext.Provider>
+	)
+}
+
+export default NotificationsProvider

--- a/src/routes/drawer.routes.tsx
+++ b/src/routes/drawer.routes.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, View } from 'react-native'
 import CustomDrawer from '../components/CustomDrawer'
 import { AuthContext } from '../context/Auth'
 import Login from '../screens/Login'
+import Notifications from '../screens/Notifications'
 import PetRegistration from '../screens/PetRegistration'
 import Profile from '../screens/Profile'
 import UserRegister from '../screens/UserRegister'
@@ -74,6 +75,14 @@ const RootRoutes = () => {
 						component={AdoptStack}
 						options={{
 							title: 'Adotar',
+							headerShown: false,
+						}}
+					/>
+					<RootDrawer.Screen
+						name='Notifications'
+						component={Notifications}
+						options={{
+							title: 'Notificações',
 							headerShown: false,
 						}}
 					/>

--- a/src/routes/types/index.ts
+++ b/src/routes/types/index.ts
@@ -18,6 +18,7 @@ export type RootDrawerParamList = {
 	Profile: undefined
 	PetRegistration: undefined
 	AdoptStack: NavigatorScreenParams<AdoptParamList>
+	Notifications: undefined
 }
 
 export type PetRegistrationProps = DrawerScreenProps<RootDrawerParamList, 'PetRegistration'>

--- a/src/screens/Notifications/index.tsx
+++ b/src/screens/Notifications/index.tsx
@@ -1,0 +1,25 @@
+import { useContext } from 'react'
+import { Button, Text, View } from 'react-native'
+import { NotificationsContext } from '../../context/Notifications'
+
+const Notifications = () => {
+	const { expoPushToken, notification, sendPushNotification } = useContext(NotificationsContext)
+	return (
+		<View style={{ flex: 1, alignItems: 'center', justifyContent: 'space-around' }}>
+			<Text>Your expo push token: {expoPushToken}</Text>
+			<View style={{ alignItems: 'center', justifyContent: 'center' }}>
+				<Text>Title: {notification && notification.request.content.title} </Text>
+				<Text>Body: {notification && notification.request.content.body}</Text>
+				<Text>Data: {notification && JSON.stringify(notification.request.content.data)}</Text>
+			</View>
+			<Button
+				title='Press to Send Notification'
+				onPress={() => {
+					sendPushNotification(expoPushToken)
+				}}
+			/>
+		</View>
+	)
+}
+
+export default Notifications


### PR DESCRIPTION
A logica de notifications foi transformado em contexto.  Não sei se é essa é a melhor forma, mas foi a maneira que encontrei de extrair a lógica do arquivo principal (App.tsx) sem afetar o projeto.
Alem disso, foi criado uma página sketch para apresentar a notificação