### PR TITLE
Ma 43/feat/notification inbox

### DIFF
--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -1,26 +1,36 @@
-import PropTypes from 'prop-types'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 export type Props = {
-	text: string,
-	styleButton?: any,
-	styleText?: any,
-	iconComponent?: any,
-	onPress?: any 
+	text: string
+	styleButton?: any
+	styleText?: any
+	iconComponent?: any
+	onPress?: any
+	disabled?: boolean
 }
 
 const MainButton: React.FC<Props> = ({
-    text,
-    styleButton,
-    styleText,
-    iconComponent,
-    onPress
+	text,
+	styleButton,
+	styleText,
+	iconComponent,
+	onPress,
+	disabled,
 }) => {
+	const handleOnPress = () => {
+		if (!disabled) onPress()
+	}
 
 	return (
-		<TouchableOpacity style={[styles.button, styleButton]} onPress={onPress}>
+		<TouchableOpacity
+			style={[styles.button, styleButton, disabled && styles.disabledButton]}
+			onPress={handleOnPress}
+			disabled={disabled}
+		>
 			{iconComponent && <View style={styles.iconContainer}>{iconComponent}</View>}
-			<Text style={[styles.buttonText, styleText]}>{text.toUpperCase()}</Text>
+			<Text style={[styles.buttonText, styleText, disabled && styles.disabledText]}>
+				{text.toUpperCase()}
+			</Text>
 		</TouchableOpacity>
 	)
 }
@@ -41,6 +51,12 @@ const styles = StyleSheet.create({
 	buttonText: {
 		color: '#434343', // Default text color
 		fontSize: 12,
+	},
+	disabledButton: {
+		backgroundColor: '#ccc',
+	},
+	disabledText: {
+		fontStyle: 'italic',
 	},
 	iconContainer: {},
 })

--- a/src/components/PetList.tsx
+++ b/src/components/PetList.tsx
@@ -126,6 +126,11 @@ const PetList = ({ ownerList }: PetListType) => {
 		}
 	}
 
+	const isMyPet = (pet: PetData) => {
+		if (pet.owner === user.user_uid) return true
+		return false
+	}
+
 	if (loading) {
 		return <ActivityIndicator size='large' />
 	}
@@ -141,13 +146,13 @@ const PetList = ({ ownerList }: PetListType) => {
 								pet: {
 									id: item.id,
 									name: item.name,
-									owner: ownerList,
+									owner: isMyPet(item),
 								},
 							})
 						}
 					>
 						<PetCard
-							owner={ownerList}
+							owner={isMyPet(item)}
 							name={item.name}
 							age_range={item.age_range}
 							petId={item.id}

--- a/src/context/Notifications.tsx
+++ b/src/context/Notifications.tsx
@@ -120,7 +120,7 @@ const NotificationsProvider = ({ children }: any) => {
 		})
 
 		responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-			console.log(response)
+			// console.log('cliquei: ', response)
 		})
 
 		return () => {

--- a/src/routes/drawer.routes.tsx
+++ b/src/routes/drawer.routes.tsx
@@ -83,7 +83,6 @@ const RootRoutes = () => {
 						component={Notifications}
 						options={{
 							title: 'Notificações',
-							headerShown: false,
 						}}
 					/>
 				</RootDrawer.Group>

--- a/src/screens/Notifications/components/NotificationItem.tsx
+++ b/src/screens/Notifications/components/NotificationItem.tsx
@@ -1,0 +1,158 @@
+import { FontAwesome, Ionicons } from '@expo/vector-icons'
+import { doc, getDoc } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Image, Pressable, StyleSheet, Text, View } from 'react-native'
+import { NotificationsDataType } from '..'
+import { PetData } from '../../../components/PetList'
+import { db } from '../../../services/firebase'
+import { defaultPetImage, fetchedImageUrl } from '../../../services/images'
+import NotificationModal from './NotificationModal'
+
+const NotificationItem = ({
+	notification,
+	onModalClose,
+}: {
+	notification: NotificationsDataType
+	onModalClose: () => void
+}) => {
+	// const defaultImage = require('../../../assets/images/default-pf.png')
+	const [modalIsOpen, setModalOpen] = useState(false)
+	const [loading, setLoading] = useState(false)
+	const [pet, setPet] = useState<PetData>({} as PetData)
+	const [url, setUrl] = useState<string>('')
+
+	const status = notification.disagrement
+		? 'Não aceito'
+		: notification.agrement
+		? 'Aceito'
+		: notification.viewed
+		? 'Visualizado'
+		: 'Não visualizado'
+
+	useEffect(() => {
+		fetchPet()
+	}, [])
+
+	useEffect(() => {
+		fetchedImageUrl({
+			storageUrl: `pet/${pet.id}/image_0.png`,
+			setLoading: (state: boolean) => setLoading(state),
+			setUrl: (url: string) => setUrl(url),
+		})
+	}, [pet])
+
+	const fetchPet = async () => {
+		try {
+			setLoading(true)
+			const docRef = doc(db, 'pet', notification.petID)
+			const data = await getDoc(docRef)
+			const petData = { id: data.id, ...data.data() } as PetData
+			setPet(petData)
+		} catch (error) {
+			console.warn(error)
+		} finally {
+			setLoading(false)
+		}
+	}
+
+	const handleModalOpen = (value: boolean) => {
+		setModalOpen(value)
+		// modal is closed then realod notificaion page
+		if (!value) onModalClose()
+	}
+
+	return (
+		<>
+			<NotificationModal
+				notification={notification}
+				isOpen={modalIsOpen}
+				setIsOpen={handleModalOpen}
+				pet={pet}
+			/>
+			{loading ? (
+				<View style={styles.itemContainer}>
+					<ActivityIndicator />
+				</View>
+			) : (
+				<Pressable onPress={() => handleModalOpen(true)}>
+					<View style={styles.itemContainer}>
+						<View style={styles.flexCenter}>
+							<View style={styles.itemImage}>
+								{url === '' ? (
+									<Image style={styles.image} source={defaultPetImage} />
+								) : (
+									<Image style={styles.image} source={{ uri: url }} />
+								)}
+							</View>
+						</View>
+						<View style={styles.itemTextContainer}>
+							<Text style={styles.title}>Adoção</Text>
+							<View style={styles.info}>
+								<Text>{pet?.name?.toUpperCase()}</Text>
+								<Text>Status: {status}</Text>
+							</View>
+							<Text style={{ fontStyle: 'italic' }}>{`${notification.date.toLocaleDateString(
+								'pt-BR'
+							)}`}</Text>
+						</View>
+						<View style={styles.icon}>
+							{status === 'Aceito' && <FontAwesome name='check' size={24} color='#5ae84a' />}
+							{status === 'Não aceito' && <FontAwesome name='remove' size={24} color='#eb4034' />}
+							{status === 'Não visualizado' && (
+								<Ionicons name='notifications-sharp' size={24} color='black' />
+							)}
+							{status === 'Visualizado' && <Ionicons name='eye-sharp' size={24} color='black' />}
+						</View>
+					</View>
+				</Pressable>
+			)}
+		</>
+	)
+}
+
+const styles = StyleSheet.create({
+	itemContainer: {
+		padding: 6,
+		marginTop: 20,
+		width: 350,
+		height: 120,
+		flexDirection: 'row',
+		backgroundColor: '#fee29b',
+		borderRadius: 10,
+	},
+	itemImage: {
+		width: 100,
+		height: 100,
+	},
+	image: {
+		flex: 1,
+		width: '100%',
+		resizeMode: 'cover',
+	},
+	flexCenter: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	itemTextContainer: {
+		flex: 2,
+		alignItems: 'center',
+	},
+	icon: {
+		position: 'absolute',
+		top: 10,
+		right: 10,
+	},
+	title: {
+		fontWeight: '900',
+		fontSize: 18,
+		padding: 5,
+	},
+	info: {
+		width: '100%',
+		justifyContent: 'flex-start',
+		margin: 10,
+	},
+})
+
+export default NotificationItem

--- a/src/screens/Notifications/components/NotificationModal.tsx
+++ b/src/screens/Notifications/components/NotificationModal.tsx
@@ -1,0 +1,271 @@
+import { doc, getDoc, updateDoc } from 'firebase/firestore'
+import { useContext, useEffect, useState } from 'react'
+import {
+	ActivityIndicator,
+	Alert,
+	Image,
+	Modal,
+	Pressable,
+	StyleSheet,
+	Text,
+	View,
+} from 'react-native'
+import { NotificationsDataType } from '..'
+import MainButton from '../../../components/MainButton'
+import { PetData } from '../../../components/PetList'
+import { AuthContext, TUser } from '../../../context/Auth'
+import { db } from '../../../services/firebase'
+import { defaultUserImage, fetchedImageUrl } from '../../../services/images'
+import UserRequester from './UserRequester'
+
+type TNotificationCard = {
+	isOpen: boolean
+	setIsOpen: (value: boolean) => void
+	notification: NotificationsDataType
+	pet: PetData
+}
+
+type TFetchData = {
+	setData: (data: any) => void
+	document: string
+	documentID: string
+}
+
+const NotificationModal = ({ isOpen, setIsOpen, notification, pet }: TNotificationCard) => {
+	const { user } = useContext(AuthContext)
+	const [loading, setLoading] = useState(false)
+	const [senderUser, setSenderUser] = useState<TUser>({} as TUser)
+	// const navigation = useNavigation<RootDrawerParamList>()
+
+	useEffect(() => {
+		const subscribe = async () => {
+			setLoading(true)
+			// fetch sender user
+			await fetchData({
+				document: 'users',
+				documentID: notification.senderID,
+				setData: (data: any) => setSenderUser({ user_uid: data.id, ...data }),
+			})
+
+			// set notification as viewd if not viewd yet
+			if (!notification.viewed) {
+				console.log(notification.id)
+				await updateDoc(doc(db, 'notifications', notification.id), {
+					viewed: true,
+				})
+			}
+			setLoading(false)
+		}
+
+		subscribe()
+	}, [notification.senderID, notification.petID])
+
+	const fetchData = async ({ document, documentID, setData }: TFetchData) => {
+		try {
+			const docRef = doc(db, document, documentID)
+			const data = await getDoc(docRef)
+			setData({ id: data.id, ...data.data() })
+		} catch (error) {
+			console.warn(error)
+		}
+	}
+
+	const isMyPet = (): boolean => {
+		// check if the pet is owned by the user
+		if (pet.owner !== user.user_uid) {
+			Alert.alert(
+				'Erro',
+				`Você não pode realizar essa operação pois o pet não é seu.`,
+				[
+					{
+						text: 'Ok',
+					},
+				],
+				{
+					cancelable: true,
+				}
+			)
+			return false
+		}
+		return true
+	}
+
+	const handleAgrement = async () => {
+		setLoading(true)
+		if (isMyPet()) {
+			const docRef = doc(db, 'pet', pet.id)
+			await updateDoc(docRef, {
+				owner: senderUser.user_uid,
+			})
+			// update noitification
+			await updateDoc(doc(db, 'notifications', notification.id), {
+				agrement: true,
+			})
+			Alert.alert(
+				'Adoção Aceita!',
+				`Você aceitou a adoção do pet. Agora ele é de outra pessoa.`,
+				[
+					{
+						text: 'Ok',
+					},
+				],
+				{
+					cancelable: true,
+				}
+			)
+		}
+		setLoading(false)
+		setIsOpen(false)
+	}
+
+	const handleDisagrament = async () => {
+		setLoading(true)
+		if (isMyPet()) {
+			const docRef = doc(db, 'notifications', notification.id)
+			await updateDoc(docRef, {
+				disagrement: true,
+			})
+			Alert.alert(
+				'Adoção Recusada',
+				`Você recusou a adoção do pet. Ele ainda continua sendo seu.`,
+				[
+					{
+						text: 'Ok',
+					},
+				],
+				{
+					cancelable: true,
+				}
+			)
+		}
+		setLoading(false)
+		setIsOpen(false)
+	}
+
+	const handleOpenChat = () => {
+		if (isMyPet()) {
+			console.warn('OpenChat')
+		}
+	}
+
+	return (
+		<Modal
+			animationType='fade'
+			transparent={true}
+			visible={isOpen}
+			onRequestClose={() => setIsOpen(false)}
+		>
+			<Pressable
+				style={styles.centeredView}
+				onPress={(event: any) => event.target === event.currentTarget && setIsOpen(false)}
+			>
+				{loading ? (
+					<ActivityIndicator />
+				) : (
+					<View style={styles.modalView}>
+						<Text style={styles.title}>{notification.message.title}</Text>
+						<Text style={styles.textCenter}>{notification.message.body}</Text>
+						<Text style={styles.textCenter}>
+							Data:{' '}
+							{`${notification.date.toLocaleDateString(
+								'pt-BR'
+							)} às ${notification.date.toLocaleTimeString('pt-BR')}`}
+						</Text>
+						<UserRequester senderUser={senderUser} />
+						<View style={styles.btnContainer}>
+							<MainButton
+								text='Aprovar'
+								styleButton={{ flex: 1 }}
+								onPress={handleAgrement}
+								disabled={notification.agrement || notification.disagrement}
+							/>
+							<MainButton
+								text='Desaprovar'
+								styleButton={{ flex: 1 }}
+								onPress={handleDisagrament}
+								styleText={{ fontSize: 10 }}
+								disabled={notification.agrement || notification.disagrement}
+							/>
+							<MainButton
+								text='Chat'
+								styleButton={{ flex: 1 }}
+								onPress={handleOpenChat}
+								disabled={notification.agrement || notification.disagrement}
+							/>
+						</View>
+					</View>
+				)}
+			</Pressable>
+		</Modal>
+	)
+}
+
+const UserPhoto = ({ userID }: { userID: string }) => {
+	const [url, setUrl] = useState<string>('')
+	const [loading, setLoading] = useState(false)
+
+	useEffect(() => {
+		fetchedImageUrl({
+			storageUrl: `user/${userID}/profilePicture.png`,
+			setLoading: (state: boolean) => setLoading(state),
+			setUrl: (url: string) => setUrl(url),
+		})
+	}, [])
+
+	return (
+		<View style={styles.userPhotoContainer}>
+			{loading && <ActivityIndicator />}
+			{url === '' ? (
+				<Image style={styles.image} source={defaultUserImage} />
+			) : (
+				<Image style={styles.image} source={{ uri: url }} />
+			)}
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	centeredView: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: 'rgba(52, 52, 52, 0.8)',
+	},
+	modalView: {
+		padding: 10,
+		width: '80%',
+		backgroundColor: '#fff',
+		maxHeight: '70%',
+	},
+	title: {
+		fontWeight: '900',
+		fontSize: 18,
+		padding: 5,
+		alignSelf: 'center',
+	},
+	textCenter: {
+		alignSelf: 'center',
+	},
+	image: {
+		flex: 1,
+		width: 150,
+		height: 150,
+		borderRadius: 75,
+		resizeMode: 'cover',
+	},
+	userPhotoContainer: {
+		margin: 10,
+		justifyContent: 'center',
+		alignItems: 'center',
+		width: '100%',
+		height: 150,
+	},
+	btnContainer: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		gap: 5,
+		marginVertical: 10,
+	},
+})
+
+export default NotificationModal

--- a/src/screens/Notifications/components/UserRequester.tsx
+++ b/src/screens/Notifications/components/UserRequester.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Image, ScrollView, StyleSheet, View } from 'react-native'
+import { TUser } from '../../../context/Auth'
+import ShowValue from '../../../screens/Profile/components/ShowValue'
+import { defaultUserImage, fetchedImageUrl } from '../../../services/images'
+
+const UserRequester = ({ senderUser }: { senderUser: TUser }) => {
+	const [url, setUrl] = useState<string>('')
+	const [loading, setLoading] = useState(false)
+
+	useEffect(() => {
+		fetchedImageUrl({
+			storageUrl: `user/${senderUser.user_uid}/profilePicture.png`,
+			setLoading: (state: boolean) => setLoading(state),
+			setUrl: (url: string) => setUrl(url),
+		})
+	}, [])
+
+	return (
+		<ScrollView persistentScrollbar={true} showsVerticalScrollIndicator={true}>
+			<View style={styles.container}>
+				<View style={styles.userPhotoContainer}>
+					{loading && <ActivityIndicator />}
+					{url === '' ? (
+						<Image style={styles.image} source={defaultUserImage} />
+					) : (
+						<Image style={styles.image} source={{ uri: url }} />
+					)}
+				</View>
+				<ShowValue title='NOME COMPLETO' value={senderUser.full_name} />
+				<ShowValue title='EMAIL' value={senderUser.email} />
+				<ShowValue title='TELEFONE' value={senderUser.phone} />
+				<ShowValue title='LOCALIZAÇÃO' value={senderUser.state + ', ' + senderUser.city} />
+				<ShowValue title='ENDEREÇO' value={senderUser.address} />
+			</View>
+		</ScrollView>
+	)
+}
+
+const styles = StyleSheet.create({
+	container: {
+		marginVertical: 10,
+		flex: 1,
+		width: '100%',
+	},
+	image: {
+		flex: 1,
+		width: 150,
+		height: 150,
+		borderRadius: 75,
+		resizeMode: 'cover',
+	},
+	userPhotoContainer: {
+		margin: 10,
+		justifyContent: 'center',
+		alignItems: 'center',
+		width: '100%',
+		height: 150,
+	},
+})
+
+export default UserRequester

--- a/src/screens/Notifications/index.tsx
+++ b/src/screens/Notifications/index.tsx
@@ -2,6 +2,7 @@ import { useFocusEffect } from '@react-navigation/native'
 import {
 	Query,
 	QueryDocumentSnapshot,
+	Timestamp,
 	collection,
 	getDocs,
 	limit,
@@ -10,25 +11,35 @@ import {
 	where,
 } from 'firebase/firestore'
 import { useCallback, useContext, useRef, useState } from 'react'
-import { ActivityIndicator, Button, FlatList, Text, View } from 'react-native'
-import { NotificationsContext } from '../../context/Notifications'
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native'
+import { AuthContext } from '../../context/Auth'
 import { db } from '../../services/firebase'
+import NotificationItem from './components/NotificationItem'
 
-type notificationsDataType = {
+export type NotificationsDataType = {
 	id: string
-	from: string
-	to: string
-	title: string
-	body: string
-	data: any
+	message: {
+		from: string
+		to: string
+		title: string
+		body: string
+		data: any
+	}
+	petID: string
+	senderID: string
+	recieverID: string
+	viewed: boolean
+	agrement: boolean
+	disagrement: boolean
+	date: Date
 }
 
 const Notifications = () => {
-	const { expoPushToken, notification, sendPushNotification } = useContext(NotificationsContext)
+	const { user } = useContext(AuthContext)
 	const itemsPerPage = 7
 	const [loading, setLoading] = useState(false)
 	const [loadingMoreContent, setLoadMoreContent] = useState(false)
-	const [notificationsData, setNotificationsData] = useState<notificationsDataType[]>([])
+	const [notificationsData, setNotificationsData] = useState<NotificationsDataType[]>([])
 	const lastDocRef = useRef<QueryDocumentSnapshot>()
 
 	useFocusEffect(
@@ -38,7 +49,7 @@ const Notifications = () => {
 		}, [])
 	)
 
-	const queryDataInDB = async (queryMounted: Query): Promise<notificationsDataType[]> => {
+	const queryDataInDB = async (queryMounted: Query): Promise<NotificationsDataType[]> => {
 		const querySnapshot = await getDocs(queryMounted)
 		// last visible document
 		lastDocRef.current = querySnapshot.docs[querySnapshot.docs.length - 1]
@@ -46,8 +57,9 @@ const Notifications = () => {
 		// build the data to be insert into pets array
 		querySnapshot.forEach((doc) => {
 			const data = doc.data()
-			dataArray.push({ id: doc.id, ...data })
-			// console.log(doc.id)
+			const date = new Timestamp(data.date.seconds, data.date.nanoseconds).toDate()
+			dataArray.push({ id: doc.id, ...data, date })
+			// console.warn('data: ', date.toLocaleDateString('pt-BR'), date.toLocaleTimeString('pt-BR'))
 		})
 
 		return dataArray
@@ -60,13 +72,11 @@ const Notifications = () => {
 			const queryMounted: Query = query(
 				collection(db, 'notifications'),
 				limit(itemsPerPage),
-				where('to', '==', expoPushToken)
+				where('recieverID', '==', user.user_uid)
 			)
 
 			const dataArray = await queryDataInDB(queryMounted)
 			setNotificationsData(dataArray)
-			console.log(notificationsData.length, 'notificationsData size')
-			console.log('notifcationsData: ', notificationsData)
 		} catch (error) {
 			console.warn(error)
 		} finally {
@@ -84,13 +94,11 @@ const Notifications = () => {
 				collection(db, 'notifications'),
 				startAfter(lastDocRef.current),
 				limit(itemsPerPage),
-				where('to', '==', expoPushToken)
+				where('recieverID', '==', user.user_uid)
 			)
 			const dataArray = await queryDataInDB(queryMounted)
 			const newNotificationsArray = [...notificationsData, ...dataArray]
 			setNotificationsData(newNotificationsArray)
-			console.log(dataArray.length, 'newPets size')
-			console.log('notifcationsData: ', notificationsData)
 		} catch (error) {
 			console.log(error)
 		} finally {
@@ -98,39 +106,40 @@ const Notifications = () => {
 		}
 	}
 
+	const refreshData = () => {
+		setLoading(false)
+		setLoadMoreContent(false)
+		setNotificationsData([])
+		lastDocRef.current = undefined
+		fetchInitialData()
+	}
+
 	if (loading) {
 		return <ActivityIndicator size='large' />
 	}
 
 	return (
-		<View style={{ flex: 1, alignItems: 'center', justifyContent: 'space-around' }}>
-			<Text>Your expo push token: {expoPushToken}</Text>
-			<View style={{ alignItems: 'center', justifyContent: 'center' }}>
-				<Text>Title: {notification && notification.request.content.title} </Text>
-				<Text>Body: {notification && notification.request.content.body}</Text>
-				<Text>Data: {notification && JSON.stringify(notification.request.content.data)}</Text>
-			</View>
+		<View style={styles.container}>
 			<FlatList
 				data={notificationsData}
-				renderItem={({ item }: { item: notificationsDataType }) => (
-					<View style={{ backgroundColor: '#88c9bf', margin: 12 }}>
-						<Text>Title: {item.title}</Text>
-						<Text>From: {item.from}</Text>
-						<Text>Body: {item.body}</Text>
-					</View>
+				renderItem={({ item }) => (
+					<NotificationItem onModalClose={refreshData} notification={item} />
 				)}
 				keyExtractor={(item) => item.id}
 				onEndReachedThreshold={0.1}
 				onEndReached={() => fetchMoreData()}
 			/>
-			<Button
-				title='Press to Send Notification'
-				onPress={() => {
-					sendPushNotification({ to: expoPushToken, from: expoPushToken })
-				}}
-			/>
 		</View>
 	)
 }
+
+const styles = StyleSheet.create({
+	container: {
+		padding: 12,
+		backgroundColor: '#fafafa',
+		flex: 1,
+		alignItems: 'center',
+	},
+})
 
 export default Notifications

--- a/src/screens/PetInfo/interfaces/index.ts
+++ b/src/screens/PetInfo/interfaces/index.ts
@@ -1,12 +1,12 @@
 export interface UserData {
-    id: string;
-    address: string;
-    age: number;
-    city: string;
-    email: string;
-    expoToken: string;
-    full_name: string;
-    phone: string;
-    state: string;
-    username: string;
+	user_uid: string
+	address: string
+	age: number
+	city: string
+	email: string
+	expoToken: string
+	full_name: string
+	phone: string
+	state: string
+	username: string
 }

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -79,3 +79,9 @@ export const fetchedImagesUrl = async ({
 		setUrls,
 	})
 }
+
+import {
+	default as defaultPetImage,
+	default as defaultUserImage,
+} from '../assets/images/default-pf.png'
+export { defaultPetImage, defaultUserImage }


### PR DESCRIPTION
Sistema de notificação

O banco de dados foi alterado para conter alguns campos relevantes:
 - viewed: boolean que identifica se o usuário clickou na notificação
 - disgrament: boolean para indicar que o dono do pet recusou o pedido de adoção
 - agrement: boolean para indicar que o dono concordou com o pedido de adoção

A página de notificação apresenta todas as notificações do usuário (faz fetch no banco pelo ID)
A notificação possui os seguintes status:
- Visualizado/Não visualizado
- Aceito/Não aceito (indica se o dono aceitou ou não o pedido de adoção)

Ao clicar no card da notificação, um modal é aberto contendo mais informações, como a mensagem da notificação, os dados do usuario que deseja adotar o pet e o botões: aprovar, desaprovar e chat
Ao clicar no botão 'aprovar', o banco de dados atualiza a notificação (agrement = true) e troca o dono do pet
Ao clicar no botão 'desaprovar' o banco de dados é atualizado (disagrament = false)

Não é possível mandar mais de uma notificação (evitar spam)
Não é possível mandar notificação para o dono do pet caso ele já tenha recusado um pedido anterior
 

TODO: 
 - Ordenar notificações na página de notificação por data (mais atual para mais antiga)
 - Ao clicar na notificação, abrir a página de notificação do usuário logado (bem simples).
 - Opcional: Mandar uma notificação quando o dono recusa o pedido de adoção para o solicitante